### PR TITLE
release: navigation loading feedback (top bar + article skeleton)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# history
+history-chats/
+
+# playwright mcp verification artifacts (local browser-test output, not for repo)
+.playwright-mcp/

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import {
   Section,
   WebsiteSchema,
   PerformanceMonitor,
+  TopLoadingBar,
 } from "@/components";
 import cx from "classnames";
 import { ThemeProvider } from "@/lib/theme-provider";
@@ -81,6 +82,7 @@ export default async function RootLayout({
         )}
       >
         <ThemeProvider attribute='class' defaultTheme='system' enableSystem>
+          <TopLoadingBar />
           <main className='py-6 gap-y-2 mx-auto flex flex-col h-screen justify-between px-2 md:px-0'>
             <div className='grow flex flex-col'>
               <NavigationHeader

--- a/src/app/posts/[slug]/loading.tsx
+++ b/src/app/posts/[slug]/loading.tsx
@@ -1,0 +1,21 @@
+import { PostSkeleton } from "@/components/kit/loaders";
+
+// Streamed instantly via Suspense while the server renders the MDX article.
+// Mirrors the layout of posts/[slug]/page.tsx so the real content swaps in
+// without a jump: title block, hero image, then body lines.
+export default function Loading() {
+  return (
+    <div className='mt-20 h-full'>
+      <article className='px-5 mx-auto'>
+        {/* Title */}
+        <div className='mx-auto my-10 h-10 md:h-14 w-3/4 rounded-xl animate-pulse dark:bg-dark-400 bg-light-400' />
+        {/* Hero image */}
+        <div className='my-10 h-64 md:h-96 w-full rounded-xl animate-pulse dark:bg-dark-400 bg-light-400' />
+        {/* Body */}
+        <section className='text-lg'>
+          <PostSkeleton />
+        </section>
+      </article>
+    </div>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,6 +7,7 @@ export { default as Footer } from "./kit/footer";
 export { default as CTA } from "./kit/cta";
 export { default as ContentRender } from "./kit/content-render";
 export { default as PostCard } from "./kit/post-card";
+export { default as TopLoadingBar } from "./kit/top-loading-bar";
 export {
   PersonSchema,
   BlogPostingSchema,

--- a/src/components/kit/loaders.tsx
+++ b/src/components/kit/loaders.tsx
@@ -1,17 +1,17 @@
 export const PostsSkeleton = () => (
   <div className='flex flex-wrap rounded-xl p-4'>
-    <div className='h-44 w-44 rounded-xl animate-pulse dark:bg-dark-100 bg-light-100' />
+    <div className='h-44 w-44 rounded-xl animate-pulse dark:bg-dark-400 bg-light-400' />
     <div className='pl-6 pt-6 sm:pt-0 w-full sm:w-2/3 flex flex-col gap-4'>
       <div className=''>
-        <div className='w-full rounded-xl h-8 mb-2 animate-pulse dark:bg-dark-100 bg-light-100' />
+        <div className='w-full rounded-xl h-8 mb-2 animate-pulse dark:bg-dark-400 bg-light-400' />
         <div className='flex items-center gap-4 mb-4'>
-          <div className='w-20 h-6 rounded-xl animate-pulse dark:bg-dark-100 bg-light-100' />
-          <div className='w-20 h-6 rounded-xl animate-pulse dark:bg-dark-100 bg-light-100' />
-          <div className='w-20 h-6 rounded-xl animate-pulse dark:bg-dark-100 bg-light-100' />
+          <div className='w-20 h-6 rounded-xl animate-pulse dark:bg-dark-400 bg-light-400' />
+          <div className='w-20 h-6 rounded-xl animate-pulse dark:bg-dark-400 bg-light-400' />
+          <div className='w-20 h-6 rounded-xl animate-pulse dark:bg-dark-400 bg-light-400' />
         </div>
-        <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-100 bg-light-100' />
-        <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-100 bg-light-100' />
-        <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-100 bg-light-100' />
+        <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-400 bg-light-400' />
+        <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-400 bg-light-400' />
+        <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-400 bg-light-400' />
       </div>
     </div>
   </div>
@@ -19,13 +19,13 @@ export const PostsSkeleton = () => (
 
 export const PostSkeleton = () => (
   <div className='flex flex-col gap-4 rounded-xl p-4'>
-    <div className='w-full rounded-xl h-8 mb-2 animate-pulse dark:bg-dark-100 bg-light-100' />
-    <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-100 bg-light-100' />
-    <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-100 bg-light-100' />
-    <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-100 bg-light-100' />
-    <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-100 bg-light-100' />
-    <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-100 bg-light-100' />
-    <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-100 bg-light-100' />
-    <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-100 bg-light-100' />
+    <div className='w-full rounded-xl h-8 mb-2 animate-pulse dark:bg-dark-400 bg-light-400' />
+    <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-400 bg-light-400' />
+    <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-400 bg-light-400' />
+    <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-400 bg-light-400' />
+    <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-400 bg-light-400' />
+    <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-400 bg-light-400' />
+    <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-400 bg-light-400' />
+    <div className='w-full rounded-xl h-4 mb-2 animate-pulse dark:bg-dark-400 bg-light-400' />
   </div>
 );

--- a/src/components/kit/top-loading-bar.tsx
+++ b/src/components/kit/top-loading-bar.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
+
+/**
+ * A thin progress bar pinned to the top of the viewport that gives instant
+ * feedback while a route transition is in flight. In the App Router a click on
+ * an internal <Link> blocks on the server until the new page is ready, so we:
+ *   1. start (and "trickle") the bar the moment an internal link is clicked
+ *   2. snap it to 100% and fade it out once the new pathname commits
+ */
+export default function TopLoadingBar() {
+  const pathname = usePathname();
+  const [visible, setVisible] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [fading, setFading] = useState(false);
+
+  const activeRef = useRef(false);
+  const trickleRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  const clearTimers = () => {
+    if (trickleRef.current) {
+      clearInterval(trickleRef.current);
+      trickleRef.current = null;
+    }
+    timersRef.current.forEach(clearTimeout);
+    timersRef.current = [];
+  };
+
+  const start = useCallback(() => {
+    if (activeRef.current) return;
+    activeRef.current = true;
+    clearTimers();
+    setFading(false);
+    setVisible(true);
+    setProgress(8);
+    // Ease toward 90% so the bar keeps moving while we wait on the server.
+    trickleRef.current = setInterval(() => {
+      setProgress((p) => (p >= 90 ? p : p + (90 - p) * 0.1));
+    }, 220);
+  }, []);
+
+  const finish = useCallback(() => {
+    if (!activeRef.current) return;
+    activeRef.current = false;
+    clearTimers();
+    setProgress(100);
+    timersRef.current.push(
+      setTimeout(() => setFading(true), 180),
+      setTimeout(() => {
+        setVisible(false);
+        setProgress(0);
+        setFading(false);
+      }, 520)
+    );
+  }, []);
+
+  // Kick off the bar on any same-origin link click that changes the path.
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (
+        e.defaultPrevented ||
+        e.button !== 0 ||
+        e.metaKey ||
+        e.ctrlKey ||
+        e.shiftKey ||
+        e.altKey
+      )
+        return;
+
+      const anchor = (e.target as HTMLElement | null)?.closest?.("a");
+      if (!anchor) return;
+
+      const href = anchor.getAttribute("href");
+      const target = anchor.getAttribute("target");
+      if (!href || (target && target !== "_self")) return;
+      if (anchor.hasAttribute("download")) return;
+
+      let url: URL;
+      try {
+        url = new URL(href, window.location.href);
+      } catch {
+        return;
+      }
+      if (url.origin !== window.location.origin) return;
+      // Same path (hash links / current page) won't trigger a navigation.
+      if (url.pathname === window.location.pathname) return;
+
+      start();
+    };
+
+    document.addEventListener("click", onClick, true);
+    return () => document.removeEventListener("click", onClick, true);
+  }, [start]);
+
+  // The route has committed once the pathname changes — complete the bar.
+  const firstRender = useRef(true);
+  useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+      return;
+    }
+    finish();
+  }, [pathname, finish]);
+
+  useEffect(() => clearTimers, []);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      aria-hidden
+      className='fixed inset-x-0 top-0 z-[9999] h-[3px] pointer-events-none'
+    >
+      <div
+        className='h-full rounded-r-full bg-light-300 dark:bg-dark-300 transition-[width,opacity] duration-200 ease-out'
+        style={{
+          width: `${progress}%`,
+          opacity: fading ? 0 : 1,
+          boxShadow:
+            "0 0 8px rgba(13,13,13,0.45), 0 0 4px rgba(13,13,13,0.45)",
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Promotes the navigation loading work from `qa` to `main` (production).

Includes #18:
- **Top progress bar** — thin bar pinned to the top of the viewport, starts on internal link clicks and completes when the route commits.
- **Streamed article skeleton** — `posts/[slug]/loading.tsx` renders an instant Suspense skeleton while the MDX article is server-rendered.
- **Fix** — `PostSkeleton` blocks used a shade identical to the page background (invisible outside a card); bumped so they contrast on the article page.
- **Chore** — gitignore `.playwright-mcp/` local verification artifacts.

Verified on the feature branch: `tsc --noEmit` + `next lint` clean; top bar and skeleton confirmed in a real browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)