### PR TITLE
fix: show full hero image in post cards instead of cropping to fixed height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ history-chats/
 
 # playwright mcp verification artifacts (local browser-test output, not for repo)
 .playwright-mcp/
+
+# local launch config for the preview tool
+.claude/
+

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/react-dom": "^18.2.21",
     "eslint": "^9.31.0",
     "eslint-config-next": "15.3.5",
+    "image-size": "^2.0.2",
     "postcss": "^8.4.35",
     "shiki": "^3.8.1",
     "tailwindcss": "^3.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       eslint-config-next:
         specifier: 15.3.5
         version: 15.3.5(eslint@9.31.0(jiti@1.21.7))(typescript@5.8.3)
+      image-size:
+        specifier: ^2.0.2
+        version: 2.0.2
       postcss:
         specifier: ^8.4.35
         version: 8.5.6
@@ -1431,6 +1434,11 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  image-size@2.0.2:
+    resolution: {integrity: sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==}
+    engines: {node: '>=16.x'}
+    hasBin: true
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -4004,6 +4012,8 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  image-size@2.0.2: {}
 
   import-fresh@3.3.1:
     dependencies:

--- a/src/components/kit/post-card.tsx
+++ b/src/components/kit/post-card.tsx
@@ -25,13 +25,14 @@ export default function Post(post: PostType) {
           </div>
 
           {hero_image?.url && (
-            <div className='w-full bg-light-200 dark:bg-dark-200 h-44 rounded-b-xl flex items-center justify-center'>
+            <div className='w-full mt-auto bg-light-200 dark:bg-dark-200 rounded-b-3xl overflow-hidden'>
               <Image
                 alt={post.slug}
                 src={hero_image.url}
                 width={hero_image.width}
                 height={hero_image.height}
-                className='h-full w-full object-cover rounded-b-xl'
+                sizes='(min-width: 768px) 50vw, 100vw'
+                className='w-full h-auto'
               />
             </div>
           )}

--- a/src/lib/mdx-posts.ts
+++ b/src/lib/mdx-posts.ts
@@ -1,9 +1,32 @@
 import fs from "fs";
 import path from "path";
+import { imageSize } from "image-size";
 import { parseDate, formatDate as formatDateUtil } from "./date-utils";
 
 const root = process.cwd();
 const postsDirectory = path.join(root, "content", "posts");
+const publicDirectory = path.join(root, "public");
+
+// Default for missing/unreadable images. Matches the 1200x630 OG ratio the
+// generated hero images use so cards keep a sane aspect while loading.
+const FALLBACK_HERO_SIZE = { width: 1200, height: 630 };
+
+// Reads the intrinsic size of a hero image under /public so the card can
+// reserve the correct aspect box instead of cropping into a fixed height.
+function getHeroImage(url: string | undefined): Post["hero_image"] {
+  if (!url) return { url: "", ...FALLBACK_HERO_SIZE };
+  if (!url.startsWith("/")) return { url, ...FALLBACK_HERO_SIZE };
+
+  try {
+    const { width, height } = imageSize(
+      fs.readFileSync(path.join(publicDirectory, url))
+    );
+    if (width && height) return { url, width, height };
+  } catch {
+    // Missing or unreadable file — fall through to fallback dimensions
+  }
+  return { url, ...FALLBACK_HERO_SIZE };
+}
 
 export interface Post {
   id: string;
@@ -116,11 +139,7 @@ export const getAllPosts = async (): Promise<Post[]> => {
         excerpt: metadata.excerpt || "",
         date: metadata.date || "",
         tags: Array.isArray(metadata.tags) ? metadata.tags : [],
-        hero_image: {
-          url: metadata.hero_image || "",
-          width: 800,
-          height: 400,
-        },
+        hero_image: getHeroImage(metadata.hero_image),
         content,
         seo: metadata.seo || {
           openGraph: {
@@ -168,11 +187,7 @@ export const getSinglePost = async (slug: string): Promise<Post | null> => {
       excerpt: metadata.excerpt || "",
       date: metadata.date || "",
       tags: Array.isArray(metadata.tags) ? metadata.tags : [],
-      hero_image: {
-        url: metadata.hero_image || "",
-        width: 800,
-        height: 400,
-      },
+      hero_image: getHeroImage(metadata.hero_image),
       content,
       seo: metadata.seo || {
         openGraph: {


### PR DESCRIPTION
## What changed

Post cards were forcing every hero image into a fixed 176px (`h-44`) box with `object-cover`, so any image not exactly that ratio got sliced. The 1200×630 illustrations lost their bottom caption strip, the square auth-configuration image lost ~65% of its height, and the wide Tailwind banner was upscaled and cropped on the sides.

- **`src/lib/mdx-posts.ts`** — new `getHeroImage()` reads each hero's real intrinsic size at build time via `image-size` (dev dep, no client JS) instead of hardcoding `800×400` for every post. `next/image` uses these to reserve the correct aspect box, so no layout shift.
- **`src/components/kit/post-card.tsx`** — drop `h-44` / `object-cover`; render at natural aspect with `w-full h-auto`, add a `sizes` hint for the 2-col grid, and match the container radius to the card (`rounded-b-3xl`) so the corners no longer show a gap.
- `.gitignore` — ignore `.claude/` (local preview-tool launch config).

## Why

Every card was cropping the illustration by however much it was taller than 176px at the column width — most visibly the "Pages that appear the moment you click" caption on the Instant Navigations card.

## Reviewer notes

- Card heights now vary with the image ratio (the square auth image makes its card taller). If uniform rows are preferred, the alternative is `object-contain` in a fixed-ratio box, which would letterbox the two old non-OG images.
- Verified in-browser: every card renders at its exact natural ratio (392×206, 392×392, 392×122). `tsc`, eslint on changed files, and `next build` pass.
- Targets `qa` per the feature → qa → main workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)